### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -25,4 +20,15 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
-
+    groups:
+      ai-dial-ci:
+        applies-to: version-updates
+        patterns:
+          - "epam/ai-dial-ci/*"
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "epam/ai-dial-ci/*"
+    open-pull-requests-limit: 10

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,12 +7,14 @@ on:
       - edited
       - reopened
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,5 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.0.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release Workflow
 on:
   push:
     branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,5 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.0.0
+    with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,42 @@
-IMAGE_NAME ?= ai-dial-code-interpreter
-VENV ?= .venv
-PYTHON_VERSION ?= 3.11
-POETRY ?= ${VENV}/bin/poetry
-POETRY_VERSION ?= 1.8.5
+ARGS ?=
+POETRY ?= poetry
+POETRY_PYTHON ?= python
+VENV_DIR ?= .venv
+
+-include .env.dev
+export
 
 .PHONY: all init_env install build test clean lint format
 
 all: build
 
 init_env:
-	python$(PYTHON_VERSION) -m venv ${VENV}
-	${VENV}/bin/pip install poetry==${POETRY_VERSION} --quiet
+	$(POETRY) env use $(POETRY_PYTHON)
 
 install: init_env
-	${POETRY} env use python$(PYTHON_VERSION)
-	${POETRY} install
+	$(POETRY) install
 
 build: install
-	${POETRY} build
-
-test:
-	@echo "No tests yet"
-
-clean:
-	${POETRY} env remove --all
+	$(POETRY) build
 
 lint: install
-	${POETRY} run nox -s lint
+	$(POETRY) run nox -s lint
 
 format: install
 	${POETRY} run nox -s format
 
+test: install
+	echo "No tests yet"
+
+clean:
+	${POETRY} env remove --all
+
 help:
-	@echo "===================="
-	@echo "build                        - build the source and wheels archives"
-	@echo "clean                        - clean virtual env and build artifacts"
-	@echo "-- LINTING --"
-	@echo "format                       - run code formatters"
-	@echo "lint                         - run linters"
+	@echo '===================='
+	@echo 'build                        - build the source and wheels archives'
+	@echo 'clean                        - clean virtual env and build artifacts'
+	@echo '-- LINTING --'
+	@echo 'format                       - run code formatters'
+	@echo 'lint                         - run linters'
+	@echo '-- TESTS --'
+	@echo 'test                         - run tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aidial-code-interpreter"
-version = "0.2.0rc"
+version = "0.0.0"
 description = "DIAL Python Code Interpreter uses Jupiter Kernel to execute code"
 authors = ["EPAM RAIL <SpecialEPM-DIALDevTeam@epam.com>"]
 homepage = "https://epam-rail.com"


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in pyproject.toml file to dev marker (`0.0.0`)
- fix Makefile to use correct virtualenv variable and align with other repos
- fix dependabot configuration