### PR TITLE
ci: re-use venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ POETRY ?= poetry
 POETRY_PYTHON ?= python
 VENV_DIR ?= .venv
 
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
+CI ?=
+
 -include .env.dev
 export
 
@@ -11,7 +14,7 @@ export
 all: build
 
 init_env:
-	$(POETRY) env use $(POETRY_PYTHON)
+	$(if $(CI),,$(POETRY) env use $(POETRY_PYTHON))
 
 install: init_env
 	$(POETRY) install

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,6 @@
-import os
-
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
-if os.environ.get("CI"):
-    nox.options.default_venv_backend = "none"
 
 SRC = "."
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,10 @@
+import os
+
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 SRC = "."
 


### PR DESCRIPTION
CI speed-up:
- skip `poetry env use` when running in CI environment - no need to recreate the venv we already prepared in workflow script (`python_prepare` action)

For local execution everything stays the same